### PR TITLE
Set short name

### DIFF
--- a/libweetwit/tweet.py
+++ b/libweetwit/tweet.py
@@ -74,7 +74,7 @@ class Tweet(Status):
 
         for url in url_list:
             try:
-                replacement = "%s [%s]" % (url['display_url'], url['url'])
+                replacement = "%s %s" % (url['display_url'], url['url'])
                 text = text.replace(url['url'], replacement)
             except (TypeError, KeyError):
                 pass

--- a/libweetwit/twitter.py
+++ b/libweetwit/twitter.py
@@ -91,7 +91,7 @@ class Twitter(object):
     def get_followed(self):
         """Returns an array of screen_names that you follow."""
         try:
-            followed = [u.screen_name for u in self.api.friends()]
+            followed = [u.screen_name for u in self.api.friends(count=200)]
         except TweepError as error:
             raise TwitterError("Faled to get followed: %s" % error)
         return followed

--- a/plugin/weetwit.py
+++ b/plugin/weetwit.py
@@ -178,11 +178,9 @@ def display_cb(data, remaining_calls):
     try:
         for tweet in StatusMonitor(status_dir, twitter.api):
 
-            tweep_color = wc.color(wc.config_get_plugin("nick_color"))
-            if tweep_color == 'nick_color':
-                tweep_color = wc.info_get("irc_nick_color", tweet.screen_name)
+            nick_color = wc.info_get("irc_nick_color", tweet.screen_name)
             for buf in valid_buffers:
-                screen_name = tweep_color + "@" + tweet.screen_name
+                screen_name = nick_color + tweet.screen_name
 
                 text = tweet.txt_unescaped
                 if expand_urls:
@@ -280,8 +278,8 @@ def conversation_cb(data, buffer, args):
         # Now display the conversation.
         print_to_current("%s-------------------" % wc.color("magenta"))
         for tweet in conversation:
-            tweep_color = wc.info_get("irc_nick_color", tweet.screen_name)
-            screen_name = tweep_color + tweet.screen_name
+            nick_color = wc.info_get("irc_nick_color", tweet.screen_name)
+            screen_name = nick_color + tweet.screen_name
             expand_urls = wc.config_string_to_boolean(wc.config_get_plugin("expand_urls"))
             text = tweet.txt_unescaped
             if expand_urls:
@@ -308,8 +306,8 @@ def show_favorites_cb(data, buffer, args):
         print_to_current("%sFAVOURITES\t%s-------------------" %
                 (wc.color("yellow"), wc.color("magenta")))
         for fav in favs:
-            tweep_color = wc.info_get("irc_nick_color", fav.screen_name)
-            screen_name = tweep_color + fav.screen_name
+            nick_color = wc.info_get("irc_nick_color", fav.screen_name)
+            screen_name = nick_color + fav.screen_name
             expand_urls = wc.config_string_to_boolean(wc.config_get_plugin("expand_urls"))
             text = fav.text_unescaped
             if expand_urls:
@@ -695,7 +693,6 @@ if wc.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE,
             "current_color" : "cyan",
             "timelined_location" : "timelined",
             "trend_woeid" : "1",
-            "nick_color" : "blue",
             "hash_color" : "red",
             "rt_style" : "postfix",
             "expand_urls" : "true",

--- a/plugin/weetwit.py
+++ b/plugin/weetwit.py
@@ -193,16 +193,14 @@ def display_cb(data, remaining_calls):
                     screen_name = cur_color + screen_name
                     text = cur_color + text
 
-                mention_color = wc.color(wc.config_get_plugin("mention_color"))
                 hash_color = wc.color(wc.config_get_plugin("hash_color"))
-                text = re.sub(r'(?P<name>@\w+)', r"{}\1{}".format(mention_color,text_color), text)
                 text = re.sub(r'(?P<hash>#\w+)', r"{}\1{}".format(hash_color,text_color), text)
 
                 retweet_style = wc.config_get_plugin("rt_style")
 
                 output =""
                 if tweet.is_retweet:
-                    retweeter = "%s@%s" % (mention_color, tweet.rtscreen_name)
+                    retweeter = "@%s" % (tweet.rtscreen_name)
                     if retweet_style == 'postfix':
                         output = '%s\t%s%s (RT by %s%s)' % (screen_name,
                                                             text_color,
@@ -699,7 +697,6 @@ if wc.register(SCRIPT_NAME, SCRIPT_AUTHOR, SCRIPT_VERSION, SCRIPT_LICENSE,
             "trend_woeid" : "1",
             "nick_color" : "blue",
             "hash_color" : "red",
-            "mention_color" : "blue",
             "rt_style" : "postfix",
             "expand_urls" : "true",
     }

--- a/plugin/weetwit.py
+++ b/plugin/weetwit.py
@@ -7,9 +7,10 @@
 #
 # Creation Date: 2012-01-05
 #
-# Last Modified: 2013-06-17 23:48
+# Last Modified: 2014-04-28 15:35
 #
 # Created By: Daniël Franke <daniel@ams-sec.org>
+# Modified by: Tor Hveem <tor@hveem.no>
 
 # TODO:
 #   - Add conversation command, to automatically follow a conversation.
@@ -44,7 +45,7 @@ except ImportError:
 
 SCRIPT_NAME         = "weetwit"
 SCRIPT_AUTHOR       = "Daniël Franke <daniel@ams-sec.org>"
-SCRIPT_VERSION      = "0.10.0"
+SCRIPT_VERSION      = "0.10.1"
 SCRIPT_LICENSE      = "BSD"
 SCRIPT_DESC         = "Full twitter suite for Weechat."
 
@@ -85,7 +86,7 @@ def print_success(message):
 
 def add_to_nicklist(buf, nick):
     """Add nick to the nicklist."""
-    wc.nicklist_add_nick(buf, "", nick, 'bar_fg', '', '', 1)
+    wc.nicklist_add_nick(buf, "", nick, wc.info_get('irc_nick_color_name', nick), '', '', 1)
 
 def remove_from_nicklist(buf, nick):
     """Remove nick from the nicklist."""
@@ -191,8 +192,11 @@ def display_cb(data, remaining_calls):
                     screen_name = cur_color + screen_name
                     text = cur_color + text
 
-                hash_color = wc.color(wc.config_get_plugin("hash_color"))
-                text = re.sub(r'(?P<hash>#\w+)', r"{}\1{}".format(hash_color,text_color), text)
+                # Use the nick coloring hashing for hash colors so hashes get consistant and different coloring
+                def hashcolor(m):
+                    s = m.group(0)
+                    return "{}{}{}".format(wc.info_get("irc_nick_color", s), s, text_color)
+                text = re.sub(r'(?P<hash>#\w+)', hashcolor, text)
 
                 retweet_style = wc.config_get_plugin("rt_style")
 

--- a/plugin/weetwit.py
+++ b/plugin/weetwit.py
@@ -623,18 +623,21 @@ def setup_timeline(timelined, followed=False, search=False):
     global buffers
     if not search:
         name = "timeline"
+        short_name = "twitter"
         title = "%s's timeline" % user.screen_name
         prefix = "__TIMELINE"
         search = False
         buf_cb = "tweet_cb"
     else:
         name = search
+        short_name = search
         title = "Twitter search for %s" % search
         prefix = md5(search).hexdigest()
         buf_cb = "tweet_cb"
     buf = wc.buffer_new(name, buf_cb, "", "stop_timelined", prefix)
     # Some naming
     wc.buffer_set(buf, "title", title)
+    wc.buffer_set(buf, "short_name", short_name)
 
     # We want mentions to highlight.
     wc.buffer_set(buf, "highlight_words", user.screen_name)


### PR DESCRIPTION
When using relay client the name relay clients use for naming buffers is either full name or short name.
This patch fixes so buffer will be named "twitter" instead of "python.timeline"
